### PR TITLE
Running in vscode mac

### DIFF
--- a/BungieCordBlogWebAPI/readme.md
+++ b/BungieCordBlogWebAPI/readme.md
@@ -19,6 +19,77 @@ Update-Database -Context AuthDbContext
 
 Assuming all commands, work fine, double check that the tables and the data insertions were successfull.
 
+## running on VS Code (Mac or Windows)
+
+I have added some notes to make this project run in VS Code. This is useful if you are trying to run this project on a Mac computer where you won't have access to Visual Studio (Purple) and stuff like SQL Management Studio and SQL Server Developer Edition and SQL Server Express. Even if are not using a Mac, it will be fun to run the project on Windows as well, just using VS Code. 
+
+Note: I still think, Windows + Visual Studio (Purple) is the best way to do .NET Programming
+
+So, here is how you can run the current project (or any .NET Project) on VS Code with SQLite. 
+
+1. dotnet tool install --global dotnet-ef
+1. dotnet add package Microsoft.EntityFrameworkCore --version 8.0.12
+1. dotnet list package
+1. dotnet clean
+1. dotnet build
+1. dotnet ef migrations add InitialCreate --context ApplicationDbContext
+1. dotnet ef database update --context ApplicationDbContext
+1. dotnet ef migrations add InitialCreate --context AuthDbContext
+1. dotnet ef database update --context AuthDbContext
+
+Update the Connection String 
+
+```
+    "ConnectionString": "Data Source=BungieCordBlogDB.sqlite"
+```
+
+Also, in Program.cs, 
+
+```
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("ConnectionString")));
+
+builder.Services.AddDbContext<AuthDbContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("ConnectionString")));
+
+```
+
+Also, your AuthDBContext needs to be modified. SQLite has some limitations which the Microsoft Authentication library does not take into consideration.
+
+```
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            base.OnModelCreating(builder);
+
+            // Check if the database provider is SQLite
+            if (Database.IsSqlite())
+            {
+                // Apply SQLite-specific configurations
+                builder.Entity<IdentityUser>(entity =>
+                {
+                    entity.Property(u => u.NormalizedEmail).HasMaxLength(256);
+                    entity.Property(u => u.NormalizedUserName).HasMaxLength(256);
+                });
+
+                builder.Entity<IdentityRole>(entity =>
+                {
+                    entity.Property(r => r.NormalizedName).HasMaxLength(256);
+                });
+            }
+
+            //rest of the code
+```
+
+Now, assuming all the above goes fine, you simply need to go to 
+
+1. View
+1. Command Palette
+1. Search for Debug
+1. Start Debugging
+   1. You may have to select C# debugging at some point if it is not already selected
+
+Also, sometimes the swagger UI will not load automatically. You might see, 'site not found' or some error. Don't panic. Simply add the URL path, https://localhost:7226/swagger/index.html, and go to Swagger UI. 
+
 ## Note
 
 1. As of now, I have commented out all the Authorize attributes. Add them in a future version, and remove this TODO.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bungie Cord Blog - Version 0.0.4
+# Bungie Cord Blog - Version 0.0.5
 
 Blogging idea project that shows a web api (.NET) and front end (Angular
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -26,6 +26,7 @@ Repo is [available here](https://github.com/Jay-study-nildana/BungieCordBlog)
     1. Then, proceed to create blog posts
     1. Blog Posts become visible on the home page
 1. TODO : Add Register to the web app
+2. Detailed instructions on how to the run web api in VS Code (Mac or Windows) are [availble here](https://github.com/Jay-study-nildana/BungieCordBlog/tree/main/BungieCordBlogWebAPI)
 
 ## User Account Registration
 


### PR DESCRIPTION
In Version 0.0.5, following changes are made

1. Tested the code on VS Code, Windows as well as Mac
1. Updated the readme file for the web api to provide detailed command line to run the web api project in the VS Code
1. Makes the current web api project usable for students who are either on Mac
1. Makes the current web api project usable for students who are on windows, but want to do all their coding on VS Code and not use Visual Studio for some reason.