### PR TITLE
Update Program.cs

### DIFF
--- a/BungieCordBlogWebAPI/BungieCordBlogWebAPI/Program.cs
+++ b/BungieCordBlogWebAPI/BungieCordBlogWebAPI/Program.cs
@@ -86,6 +86,12 @@ app.UseCors(options =>
 app.UseAuthentication();
 app.UseAuthorization();
 
+var imagesPath = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+if (!Directory.Exists(imagesPath))
+{
+    Directory.CreateDirectory(imagesPath);
+}
+
 app.UseStaticFiles(new StaticFileOptions
 {
     FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), "Images")),


### PR DESCRIPTION
Added Code to check if Images folder does not exist. 

If images folder does not exist, it gets created. This is essential because I have gotten to the habit of not pushing the image folder (because sometimes, the images are personal and don't want it in a public repo), and simply deleting it after every development run. 

But, once the images folder is deleted, it was giving a run time error. Now that error has been removed.